### PR TITLE
Adds our-active-class Taghelper

### DIFF
--- a/Our.Umbraco.TagHelpers/ActiveClassTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ActiveClassTagHelper.cs
@@ -38,6 +38,10 @@ namespace Our.Umbraco.TagHelpers
         public string ActiveClassName { get; set; }
 
 
+        /// <summary>
+        /// If you wish to add an active CSS class on another DOM element than an <a>
+        /// You can use this attribute to pass a link to the page to check in conjuction with `our-active-class` attribute
+        /// </summary>
         [HtmlAttributeName("our-active-href")]
         public string? ActiveLink { get; set; }
 

--- a/Our.Umbraco.TagHelpers/ActiveClassTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ActiveClassTagHelper.cs
@@ -14,14 +14,18 @@ namespace Our.Umbraco.TagHelpers
     /// Will apply the CSS class name navi-active to the class attribute
     /// if the value in the href of the <a> compared to the page being rendered
     /// is the current page or part of an ancestor
-    /// </summary>
+    /// </summary>"
+    [HtmlTargetElement("*", Attributes = tagHelperAttributes)]
     [HtmlTargetElement("a", Attributes = tagHelperAttributeName)]
-    public class IsActivePageTagHelper : TagHelper
+    public class ActiveClassTagHelper : TagHelper
     {
         private const string tagHelperAttributeName = "our-active-class";
+        private const string tagHelperAttributeHrefName = "our-active-href";
+        private const string tagHelperAttributes = tagHelperAttributeName + ", " + tagHelperAttributeHrefName;
+
         private IUmbracoContextAccessor _umbracoContextAccessor;
 
-        public IsActivePageTagHelper(IUmbracoContextAccessor umbracoContextAccessor)
+        public ActiveClassTagHelper(IUmbracoContextAccessor umbracoContextAccessor)
         {
             _umbracoContextAccessor = umbracoContextAccessor;
         }
@@ -33,6 +37,10 @@ namespace Our.Umbraco.TagHelpers
         [HtmlAttributeName(tagHelperAttributeName)]
         public string ActiveClassName { get; set; }
 
+
+        [HtmlAttributeName("our-active-href")]
+        public string? ActiveLink { get; set; }
+
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             // Remove the attribute 
@@ -41,8 +49,8 @@ namespace Our.Umbraco.TagHelpers
 
             var ctx = _umbracoContextAccessor.GetRequiredUmbracoContext();
 
-            // On the <a> try to find the href attribute and its value
-            var href = output.Attributes["href"]?.Value.ToString();
+            // If we have active link prop set use that othewise try to find the href attribute on an <a> and its value
+            var href = string.IsNullOrEmpty(ActiveLink) ? output.Attributes["href"]?.Value.ToString() : ActiveLink;
             if (string.IsNullOrEmpty(href))
             {
                 return;

--- a/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
@@ -33,10 +33,7 @@ namespace Our.Umbraco.TagHelpers
         {
             // Remove the attribute 
             // We don't want it in the markup we send down to the page
-            if(output.Attributes.TryGetAttribute("our-is-active-page", out TagHelperAttribute tagHelperAttr))
-            {
-                output.Attributes.Remove(tagHelperAttr);
-            }
+            output.Attributes.RemoveAll("our-is-active-page");
 
             var ctx = _umbracoContextAccessor.GetRequiredUmbracoContext();
 

--- a/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
+
+namespace Our.Umbraco.TagHelpers
+{
+    /// <summary>
+    /// An attribute TagHelper that only works with <a> tags
+    /// 
+    /// Applying the attribute our-is-active-page="navi-active"
+    /// Will apply the CSS class name navi-active to the class attribute
+    /// if the value in the href of the <a> compared to the page being rendered
+    /// is the current page or part of an ancestor
+    /// </summary>
+    [HtmlTargetElement("a", Attributes = "our-is-active-page")]
+    public class IsActivePageTagHelper : TagHelper
+    {
+        private IUmbracoContextAccessor _umbracoContextAccessor;
+
+        public IsActivePageTagHelper(IUmbracoContextAccessor umbracoContextAccessor)
+        {
+            _umbracoContextAccessor = umbracoContextAccessor;
+        }
+
+        /// <summary>
+        /// The CSS class name you wish to append to the class attribute
+        /// on an <a> tag when the page is active/selected
+        /// </summary>
+        [HtmlAttributeName("our-is-active-page")]
+        public string ActiveClassName { get; set; }
+        
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            // Remove the attribute 
+            // We don't want it in the markup we send down to the page
+            if(output.Attributes.TryGetAttribute("our-is-active-page", out TagHelperAttribute tagHelperAttr))
+            {
+                output.Attributes.Remove(tagHelperAttr);
+            }
+
+            var ctx = _umbracoContextAccessor.GetRequiredUmbracoContext();
+
+            // On the <a> try to find the href attribute and its value
+            var href = output.Attributes["href"]?.Value.ToString();
+            if (string.IsNullOrEmpty(href))
+            {
+                return;
+            }
+
+            // Clean href values of any querystrings
+            // As we won't be able to query GetByRoute for an Umbraco node with them
+            href = href.Substring(0, href.IndexOf("?") > 0 ? href.IndexOf("?") : href.Length);
+
+            // Get the node based of the value in the HREF
+            var nodeOfLink = ctx.Content.GetByRoute(href);
+            if(nodeOfLink == null)
+            {
+                return;
+            }
+
+            // Get the current node of the page that is rendering
+            var currentPageRendering = ctx.PublishedRequest.PublishedContent;
+
+            // Check if thelink we are rendering is current page or an ancestor
+            if(nodeOfLink.IsAncestorOrSelf(currentPageRendering))
+            {
+                // Is active page
+                // Check if the <a> has a class attribute already
+                if(output.Attributes.TryGetAttribute("class", out TagHelperAttribute classAttribute))
+                {
+                    var existingClasses = classAttribute.Value.ToString();
+                    output.Attributes.SetAttribute("class", existingClasses + " nav-link--active");
+                }
+                else
+                {
+                    // No class attribute exists so add a new one
+                    output.Attributes.SetAttribute("class", "nav-link--active");
+                }
+            }
+        }
+    }
+}

--- a/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
@@ -62,17 +62,7 @@ namespace Our.Umbraco.TagHelpers
             if(nodeOfLink.IsAncestorOrSelf(currentPageRendering))
             {
                 // Is active page
-                // Check if the <a> has a class attribute already
-                if(output.Attributes.TryGetAttribute("class", out TagHelperAttribute classAttribute))
-                {
-                    var existingClasses = classAttribute.Value.ToString();
-                    output.Attributes.SetAttribute("class", existingClasses + " nav-link--active");
-                }
-                else
-                {
-                    // No class attribute exists so add a new one
-                    output.Attributes.SetAttribute("class", "nav-link--active");
-                }
+                output.Attributes.AddClass(ActiveClassName, HtmlEncoder.Default);
             }
         }
     }

--- a/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/IsActivePageTagHelper.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Text.Encodings.Web;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 
 namespace Our.Umbraco.TagHelpers
 {
@@ -12,9 +14,10 @@ namespace Our.Umbraco.TagHelpers
     /// if the value in the href of the <a> compared to the page being rendered
     /// is the current page or part of an ancestor
     /// </summary>
-    [HtmlTargetElement("a", Attributes = "our-is-active-page")]
+    [HtmlTargetElement("a", Attributes = tagHelperAttributeName)]
     public class IsActivePageTagHelper : TagHelper
     {
+        private const string tagHelperAttributeName = "our-active-class";
         private IUmbracoContextAccessor _umbracoContextAccessor;
 
         public IsActivePageTagHelper(IUmbracoContextAccessor umbracoContextAccessor)
@@ -26,7 +29,7 @@ namespace Our.Umbraco.TagHelpers
         /// The CSS class name you wish to append to the class attribute
         /// on an <a> tag when the page is active/selected
         /// </summary>
-        [HtmlAttributeName("our-is-active-page")]
+        [HtmlAttributeName(tagHelperAttributeName)]
         public string ActiveClassName { get; set; }
         
         public override void Process(TagHelperContext context, TagHelperOutput output)
@@ -62,7 +65,7 @@ namespace Our.Umbraco.TagHelpers
             if(nodeOfLink.IsAncestorOrSelf(currentPageRendering))
             {
                 // Is active page
-                output.Attributes.AddClass(ActiveClassName, HtmlEncoder.Default);
+                output.AddClass(ActiveClassName, HtmlEncoder.Default);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -306,6 +306,19 @@ This allows for the navigation item to still have the class added to it when a c
 }
 ```
 
+Alternatively you can use the `our-active-class` attribute in conjuction with `our-active-href` attribute to apply this to any HTML DOM element on the page.
+
+```cshtml
+<ul>
+    @foreach (var item in Model.Root().Children)
+    {
+        <li our-active-href="@item.Url()" our-active-class="selected">
+            <a href="@item.Url()" class="nav-link" our-active-class="nav-link--active">@item.Name</a>
+        </li>    
+    }
+</ul>
+```
+
 
 ## Video 📺
 [![How to create ASP.NET TagHelpers for Umbraco](https://user-images.githubusercontent.com/1389894/138666925-15475216-239f-439d-b989-c67995e5df71.png)](https://www.youtube.com/watch?v=3fkDs0NwIE8)

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ If you want the edit link to open in a new tab, just add the `target="_blank"` a
 <our-edit-link target="_blank">Edit</our-edit-link>
 ```
 
-## `our-is-active-page`
+## `our-active-class`
 This is a tag helper attribute that can be applied to `<a>` element in the razor template or partial. It will use the value inside the attribute and append it to the class attribute of the `<a>`.
 If the link inside the href attribute can be found by its route as a content node, if so then it will check with the current page being rendered if its the same node or an ancestor.
 
@@ -302,7 +302,7 @@ This allows for the navigation item to still have the class added to it when a c
 ```cshtml
 @foreach (var item in Model.Root().Children)
 {
-    <a href="@item.Url()" class="nav-link" our-is-active-page="nav-link--active">@item.Name</a>
+    <a href="@item.Url()" class="nav-link" our-active-class="nav-link--active">@item.Name</a>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,21 @@ If you want the edit link to open in a new tab, just add the `target="_blank"` a
 <our-edit-link target="_blank">Edit</our-edit-link>
 ```
 
+## `our-is-active-page`
+This is a tag helper attribute that can be applied to `<a>` element in the razor template or partial. It will use the value inside the attribute and append it to the class attribute of the `<a>`.
+If the link inside the href attribute can be found by its route as a content node, if so then it will check with the current page being rendered if its the same node or an ancestor.
+
+This allows for the navigation item to still have the class added to it when a child or grandchildren page is the currently page being rendered.
+
+### Simple Example
+```cshtml
+@foreach (var item in Model.Root().Children)
+{
+    <a href="@item.Url()" class="nav-link" our-is-active-page="navi-link--active">@item.Name</a>
+}
+```
+
+
 ## Video 📺
 [![How to create ASP.NET TagHelpers for Umbraco](https://user-images.githubusercontent.com/1389894/138666925-15475216-239f-439d-b989-c67995e5df71.png)](https://www.youtube.com/watch?v=3fkDs0NwIE8)
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ This allows for the navigation item to still have the class added to it when a c
 ```cshtml
 @foreach (var item in Model.Root().Children)
 {
-    <a href="@item.Url()" class="nav-link" our-is-active-page="navi-link--active">@item.Name</a>
+    <a href="@item.Url()" class="nav-link" our-is-active-page="nav-link--active">@item.Name</a>
 }
 ```
 


### PR DESCRIPTION
## `our-active-class`
This is a tag helper attribute that can be applied to `<a>` element in the razor template or partial. It will use the value inside the attribute and append it to the class attribute of the `<a>`.
If the link inside the href attribute can be found by its route as a content node, if so then it will check with the current page being rendered if its the same node or an ancestor.

Fixes #15 

This allows for the navigation item to still have the class added to it when a child or grandchildren page is the currently page being rendered.

### Simple Example
```cshtml
@foreach (var item in Model.Root().Children)
{
    <a href="@item.Url()" class="nav-link" our-active-class="nav-link--active">@item.Name</a>
}
```

Alternatively you can use the `our-active-class` attribute in conjuction with `our-active-href` attribute to apply this to any HTML DOM element on the page.

```cshtml
<ul>
    @foreach (var item in Model.Root().Children)
    {
        <li our-active-href="@item.Url()" our-active-class="selected">
            <a href="@item.Url()" class="nav-link">@item.Name</a>
        </li>    
    }
</ul>
```