### PR TITLE
Add some sort of implementation of a Preview/Debug aware CacheTagHelper

### DIFF
--- a/Our.Umbraco.TagHelpers/CacheKeys/CacheKeyConstants.cs
+++ b/Our.Umbraco.TagHelpers/CacheKeys/CacheKeyConstants.cs
@@ -1,7 +1,0 @@
-﻿namespace Our.Umbraco.TagHelpers.CacheKeys
-{
-    public static class CacheKeyConstants
-    {
-        public const string LastCacheRefreshDateKey = "LastCacheRefreshDate";
-    }
-}

--- a/Our.Umbraco.TagHelpers/CacheKeys/CacheKeyConstants.cs
+++ b/Our.Umbraco.TagHelpers/CacheKeys/CacheKeyConstants.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Our.Umbraco.TagHelpers.CacheKeys
+﻿namespace Our.Umbraco.TagHelpers.CacheKeys
 {
     public static class CacheKeyConstants
     {

--- a/Our.Umbraco.TagHelpers/Composing/CacheTagHelperComposer.cs
+++ b/Our.Umbraco.TagHelpers/Composing/CacheTagHelperComposer.cs
@@ -1,9 +1,4 @@
 ﻿using Our.Umbraco.TagHelpers.Notifications;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;

--- a/Our.Umbraco.TagHelpers/Composing/CacheTagHelperComposer.cs
+++ b/Our.Umbraco.TagHelpers/Composing/CacheTagHelperComposer.cs
@@ -1,4 +1,6 @@
-﻿using Our.Umbraco.TagHelpers.Notifications;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Our.Umbraco.TagHelpers.Notifications;
+using Our.Umbraco.TagHelpers.Services;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
@@ -10,9 +12,11 @@ namespace Our.Umbraco.TagHelpers.Composing
         // handle refreshing of content/media/dictionary cache notification to clear the cache key used for the CacheTagHelper
         public void Compose(IUmbracoBuilder builder)
         {
-            builder.AddNotificationHandler<ContentCacheRefresherNotification, HandleContentCacheRefresherNotification>();
-            builder.AddNotificationHandler<MediaCacheRefresherNotification, HandleMediaCacheRefresherNotification>();
-            builder.AddNotificationHandler<DictionaryCacheRefresherNotification, HandleDictionaryCacheRefresherNotification>();
+            builder.Services.AddSingleton<IUmbracoTagHelperCacheKeys, UmbracoTagHelperCacheKeys>();
+
+            builder.AddNotificationHandler<ContentCacheRefresherNotification, CacheTagRefresherNotifications>();
+            builder.AddNotificationHandler<MediaCacheRefresherNotification, CacheTagRefresherNotifications>();
+            builder.AddNotificationHandler<DictionaryCacheRefresherNotification, CacheTagRefresherNotifications>();
         }
     }
 }

--- a/Our.Umbraco.TagHelpers/Notifications/CacheRefresherNotifications.cs
+++ b/Our.Umbraco.TagHelpers/Notifications/CacheRefresherNotifications.cs
@@ -6,10 +6,12 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace Our.Umbraco.TagHelpers.Notifications
 {
-	// For Use with the Our Cache TagHelper - to store a last cache updated datetime to use
-	// in the varyby key for the Cache TagHelper, to naively break the cache on publish.
-	// Used for ContentCacheRefresher (Load balanced scernarios not just Published event)
-	// Same for Dictionary Items and Media item
+	/// <summary>
+	/// For Use with the Our Cache TagHelper
+	/// We handle the published cache updating notification for content, media and dictionary
+	/// And then use our dictionary collection of tracked tag helper caches, created in the tag cache helper
+	/// loop through each one and clear the tag helpers cache
+	/// </summary>
 	public class CacheTagRefresherNotifications : 
 		INotificationHandler<ContentCacheRefresherNotification>,
         INotificationHandler<DictionaryCacheRefresherNotification>,

--- a/Our.Umbraco.TagHelpers/Notifications/CacheRefresherNotifications.cs
+++ b/Our.Umbraco.TagHelpers/Notifications/CacheRefresherNotifications.cs
@@ -1,16 +1,15 @@
 ﻿using Our.Umbraco.TagHelpers.CacheKeys;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 
 namespace Our.Umbraco.TagHelpers.Notifications
 {
-	// For Use with the Our Cache TagHelper - to store a last cache updated datetime to use in the varyby key for the Cache TagHelper, to naively break the cache on publish
+	// For Use with the Our Cache TagHelper - to store a last cache updated datetime to use
+	// in the varyby key for the Cache TagHelper, to naively break the cache on publish.
+	// Used for ContentCacheRefresher (Load balanced scernarios not just Published event)
+	// Same for Dictionary Items and Media item
 	public class HandleContentCacheRefresherNotification : INotificationHandler<ContentCacheRefresherNotification>
 	{
 		private readonly IAppPolicyCache _runtimeCache;
@@ -20,17 +19,19 @@ namespace Our.Umbraco.TagHelpers.Notifications
 			_runtimeCache = appCaches.RuntimeCache;
 
 		}
+
 		public void Handle(ContentCacheRefresherNotification notification)
 		{
 			// fired when content published
 			// store DateTime, as the cachekey
-
 			var lastCacheRefreshDate = DateTime.UtcNow.ToString("s");
-			//insert and override existing value in appcache
+
+			// insert and override existing value in appcache
 			_runtimeCache.Insert(CacheKeyConstants.LastCacheRefreshDateKey, () => lastCacheRefreshDate, null, false, null);
 
 		}
 	}
+
 	public class HandleDictionaryCacheRefresherNotification : INotificationHandler<DictionaryCacheRefresherNotification>
 	{
 		private readonly IAppPolicyCache _runtimeCache;
@@ -38,17 +39,19 @@ namespace Our.Umbraco.TagHelpers.Notifications
 		{
 			_runtimeCache = appCaches.RuntimeCache;
 		}
+
 		public void Handle(DictionaryCacheRefresherNotification notification)
 		{
 			// fired when Dictionary item updated
 			// store DateTime, as the cachekey
-
 			var lastCacheRefreshDate = DateTime.UtcNow.ToString("s");
-			//insert and override existing value in appcache
+
+			// insert and override existing value in appcache
 			_runtimeCache.Insert(CacheKeyConstants.LastCacheRefreshDateKey, () => lastCacheRefreshDate, null, false, null);
 
 		}
 	}
+
 	public class HandleMediaCacheRefresherNotification : INotificationHandler<MediaCacheRefresherNotification>
 	{
 		private readonly IAppPolicyCache _runtimeCache;
@@ -56,16 +59,15 @@ namespace Our.Umbraco.TagHelpers.Notifications
 		{
 			_runtimeCache = appCaches.RuntimeCache;
 		}
+
 		public void Handle(MediaCacheRefresherNotification notification)
 		{
 			// fired when media updated
 			// store DateTime, as the cachekey
-
 			var lastCacheRefreshDate = DateTime.UtcNow.ToString("s");
-			//insert and override existing value in appcache
-			_runtimeCache.Insert(CacheKeyConstants.LastCacheRefreshDateKey, () => lastCacheRefreshDate, null, false, null);
 
+			// insert and override existing value in appcache
+			_runtimeCache.Insert(CacheKeyConstants.LastCacheRefreshDateKey, () => lastCacheRefreshDate, null, false, null);
 		}
 	}
-
 }

--- a/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using System.Collections.Generic;
+
+namespace Our.Umbraco.TagHelpers.Services
+{
+	public interface IUmbracoTagHelperCacheKeys
+	{
+		Dictionary<string, CacheTagKey> CacheKeys { get; set; }
+	}
+}

--- a/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
@@ -5,6 +5,6 @@ namespace Our.Umbraco.TagHelpers.Services
 {
 	public interface IUmbracoTagHelperCacheKeys
 	{
-		Dictionary<string, CacheTagKey> CacheKeys { get; set; }
+		Dictionary<string, CacheTagKey> CacheKeys { get; }
 	}
 }

--- a/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
+using System.Collections.Generic;
+
+namespace Our.Umbraco.TagHelpers.Services
+{
+	public class UmbracoTagHelperCacheKeys : IUmbracoTagHelperCacheKeys
+	{
+		public Dictionary<string,CacheTagKey> CacheKeys { get; set; } = new Dictionary<string,CacheTagKey>();
+	}
+}

--- a/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 namespace Our.Umbraco.TagHelpers.Services
 {
+	/// <summary>
+	/// used to retain a list of hashed cache tag helper keys that have been created using the our cache tag helper
+	/// and which need to be cleared when a publish notification takes place.
+	/// </summary>
 	public class UmbracoTagHelperCacheKeys : IUmbracoTagHelperCacheKeys
 	{
 		public Dictionary<string,CacheTagKey> CacheKeys { get; } = new Dictionary<string,CacheTagKey>();

--- a/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
@@ -5,6 +5,6 @@ namespace Our.Umbraco.TagHelpers.Services
 {
 	public class UmbracoTagHelperCacheKeys : IUmbracoTagHelperCacheKeys
 	{
-		public Dictionary<string,CacheTagKey> CacheKeys { get; set; } = new Dictionary<string,CacheTagKey>();
+		public Dictionary<string,CacheTagKey> CacheKeys { get; } = new Dictionary<string,CacheTagKey>();
 	}
 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -37,11 +37,13 @@ namespace Our.Umbraco.TagHelpers
 			_umbracoContextFactory = umbracoContextFactory;
 			_runtimeCache = appCaches.RuntimeCache;
 		}
+
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
 			using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
 			{
 				var umbracoContext = umbracoContextReference.UmbracoContext;
+
 				// we don't want to enable the cache tag helper if Umbraco is in Preview, or in Debug mode
 				if (umbracoContext.InPreviewMode || umbracoContext.IsDebug)
 				{
@@ -66,8 +68,10 @@ namespace Our.Umbraco.TagHelpers
 					{
 						// ironically read the last cache refresh date from runtime cache, and set it to now if it's not there...
 						var umbLastCacheRefreshCacheKey = _runtimeCache.GetCacheItem(CacheKeyConstants.LastCacheRefreshDateKey, () => GetFallbackCacheRefreshDate()).ToString();
+						
 						// append to VaryBy key incase VaryBy key is set to some other parameter too
 						this.VaryBy = umbLastCacheRefreshCacheKey + "|" + this.VaryBy;
+						
 						// if an expiry date isn't set when using the CacheTagHelper, let's add one to be 24hrs, so when mulitple publishes occur, the versions of this taghelper don't hang around forever
 						if (this.ExpiresAfter == null)
                         {
@@ -80,16 +84,15 @@ namespace Our.Umbraco.TagHelpers
 			}
 
 		}
+
 		private string GetFallbackCacheRefreshDate()
 		{
-			//this fires if the 'appcache' doesn't have a LastCacheRefreshDate set by a publish
+			// this fires if the 'appcache' doesn't have a LastCacheRefreshDate set by a publish
 			// eg after an app pool recycle
 			// it doesn't really matter that this isn't the last datetime that something was actually published
 			// because time tends to always move forwards
 			// the next publish will set a new future LastCacheRefreshDate...
 			return DateTime.UtcNow.ToString("s");
-
 		}
-
 	}
 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -22,7 +22,7 @@ namespace Our.Umbraco.TagHelpers
         /// <summary>
         /// Whether to update the cache key when any content, media, dictionary item is published in Umbraco.
         /// </summary>
-        public bool UpdateCacheKeyOnPublish { get; set; } = true;
+        public bool UpdateCacheOnPublish { get; set; } = true;
 
         public UmbracoCacheTagHelper(CacheTagHelperMemoryCacheFactory factory,
             HtmlEncoder htmlEncoder,
@@ -53,8 +53,8 @@ namespace Our.Umbraco.TagHelpers
                     // we want to do the same by default for this tag helper
                     // we can't track by convention as dot net tag helper cache key is hashed - but we can generte the hash key here, and add it to a dictionary
                     // which we can loop through when the Umbraco cache is updated to clear the tag helper cache.
-                    // you can opt out of this by setting update-cache-key-on-publish="false" in the individual tag helper
-                    if (UpdateCacheKeyOnPublish)
+                    // you can opt out of this by setting update-cache-on-publish="false" in the individual tag helper
+                    if (UpdateCacheOnPublish)
                     {
                         // The base TagHelper would generate it's own CacheTagKey to create a unique hash
                         // but if we call it here 'too' it will fortunately be the same hash.

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -1,13 +1,11 @@
 ﻿using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Our.Umbraco.TagHelpers.CacheKeys;
-using System;
+using Our.Umbraco.TagHelpers.Services;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Web;
-using Umbraco.Extensions;
 
 namespace Our.Umbraco.TagHelpers
 {
@@ -19,23 +17,21 @@ namespace Our.Umbraco.TagHelpers
 	public class UmbracoCacheTagHelper : CacheTagHelper
     {
 		private readonly IUmbracoContextFactory _umbracoContextFactory;
-		private readonly IAppPolicyCache _runtimeCache;
-		// default to true, a very 'Umbraco' convention.
-		private bool _updateCacheKeyOnPublish = true;
+		private readonly IUmbracoTagHelperCacheKeys _cacheKeys;
 
 		/// <summary>
 		/// Whether to update the cache key when any content, media, dictionary item is published in Umbraco.
 		/// </summary>
-		public bool UpdateCacheKeyOnPublish
-		{
-			get { return _updateCacheKeyOnPublish; }
-			set { _updateCacheKeyOnPublish = value; }
-		}
+		public bool UpdateCacheKeyOnPublish { get; set; } = true;
 
-		public UmbracoCacheTagHelper(CacheTagHelperMemoryCacheFactory factory, HtmlEncoder htmlEncoder, AppCaches appCaches, IUmbracoContextFactory umbracoContextFactory) : base(factory, htmlEncoder)
+		public UmbracoCacheTagHelper(CacheTagHelperMemoryCacheFactory factory, 
+			HtmlEncoder htmlEncoder, 
+			IUmbracoContextFactory umbracoContextFactory,
+            IUmbracoTagHelperCacheKeys cacheKeys) 
+			: base(factory, htmlEncoder)
 		{
 			_umbracoContextFactory = umbracoContextFactory;
-			_runtimeCache = appCaches.RuntimeCache;
+			_cacheKeys = cacheKeys;
 		}
 
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
@@ -47,52 +43,28 @@ namespace Our.Umbraco.TagHelpers
 				// we don't want to enable the cache tag helper if Umbraco is in Preview, or in Debug mode
 				if (umbracoContext.InPreviewMode || umbracoContext.IsDebug)
 				{
+					// Set the endabled flag to false & lest base class
+					// of the cache tag helper do the same stuff as before
 					this.Enabled = false;
-					await output.GetChildContentAsync();
 				}
 				else
 				{
-					// with the CacheTagHelper we are wrapping here it's really difficult to clear the cache of the Tag Helper output 'on demand'
-					// eg when a page is published, with Umbraco's CachedPartial that's what happens, so if you change the name of a page, and the site navigation
-					// is cached with a cached partial, the cache is automatically cleared.
-					// it seems for CacheTagHelper the .net core advice when you want to break the cache is to update the varyby key, the previous key in the cache will be forgotten
-					// and fall out of the cache naturally... (but I did later on find this article: https://www.umbrajobs.com/blog/posts/2021/june/umbraco-9-net-core-caching-part-1-cashing-shared-partial-views/
-					// where it talks about being able to clear the actual cache tag using reflection.. - it won't work on loadbalanced servers - using wrong notifications!
-					// ... so maybe that's the way people will ultimately prefer to go...
-					// but for this tag helper we just track the last time a peace of content, dictionary item or media was published, and use that datetime in the varyby cachekey
-					// so everytime something is published in Umbraco, the cache tag helper will have a different cache key and this will produce a new cached result
-					// this might be a bad thing?
-					// so we have a setting to turn this off, so the tag helper is still usable as the existing .net core cache tag helper, without caching in preview or umbraco debug
-					// which is still handyish
-					if (_updateCacheKeyOnPublish)
+					// Defaults to true - have to explicitly opt out with attribute set to false in Razor
+					if (UpdateCacheKeyOnPublish)
 					{
-						// ironically read the last cache refresh date from runtime cache, and set it to now if it's not there...
-						var umbLastCacheRefreshCacheKey = _runtimeCache.GetCacheItem(CacheKeyConstants.LastCacheRefreshDateKey, () => GetFallbackCacheRefreshDate()).ToString();
-						
-						// append to VaryBy key incase VaryBy key is set to some other parameter too
-						this.VaryBy = umbLastCacheRefreshCacheKey + "|" + this.VaryBy;
-						
-						// if an expiry date isn't set when using the CacheTagHelper, let's add one to be 24hrs, so when mulitple publishes occur, the versions of this taghelper don't hang around forever
-						if (this.ExpiresAfter == null)
-                        {
-							this.ExpiresAfter = new TimeSpan(24, 0, 0);
-                        }
-					}
+                        // So before we go into our base class
+                        // Grab the cache key so we can keep track of it & put into some dictionary or collection
+                        // and clear all items out in that collection with our notifications on publish
 
-					await base.ProcessAsync(context, output);
+                        var cacheKey = new CacheTagKey(this, context);
+                        var key = cacheKey.GenerateKey();
+                        var hashedKey = cacheKey.GenerateHashedKey();
+						_cacheKeys.CacheKeys.TryAdd(key, cacheKey);
+                    }
 				}
-			}
 
-		}
-
-		private string GetFallbackCacheRefreshDate()
-		{
-			// this fires if the 'appcache' doesn't have a LastCacheRefreshDate set by a publish
-			// eg after an app pool recycle
-			// it doesn't really matter that this isn't the last datetime that something was actually published
-			// because time tends to always move forwards
-			// the next publish will set a new future LastCacheRefreshDate...
-			return DateTime.UtcNow.ToString("s");
+                await base.ProcessAsync(context, output);
+            }
 		}
 	}
 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -9,49 +9,49 @@ using Umbraco.Cms.Core.Web;
 
 namespace Our.Umbraco.TagHelpers
 {
-	/// <summary>
-	/// A wrapper around .net core CacheTagHelper so you remember not to cache in preview or Umbraco debug mode
-	/// Also can create a new variance of the cache when anything is published in Umbraco if that is desirable
-	/// </summary>
-	[HtmlTargetElement("our-cache")]
-	public class UmbracoCacheTagHelper : CacheTagHelper
+    /// <summary>
+    /// A wrapper around .net core CacheTagHelper so you remember not to cache in preview or Umbraco debug mode
+    /// Also can create a new variance of the cache when anything is published in Umbraco if that is desirable
+    /// </summary>
+    [HtmlTargetElement("our-cache")]
+    public class UmbracoCacheTagHelper : CacheTagHelper
     {
-		private readonly IUmbracoContextFactory _umbracoContextFactory;
-		private readonly IUmbracoTagHelperCacheKeys _cacheKeys;
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+        private readonly IUmbracoTagHelperCacheKeys _cacheKeys;
 
-		/// <summary>
-		/// Whether to update the cache key when any content, media, dictionary item is published in Umbraco.
-		/// </summary>
-		public bool UpdateCacheKeyOnPublish { get; set; } = true;
+        /// <summary>
+        /// Whether to update the cache key when any content, media, dictionary item is published in Umbraco.
+        /// </summary>
+        public bool UpdateCacheKeyOnPublish { get; set; } = true;
 
-		public UmbracoCacheTagHelper(CacheTagHelperMemoryCacheFactory factory, 
-			HtmlEncoder htmlEncoder, 
-			IUmbracoContextFactory umbracoContextFactory,
-            IUmbracoTagHelperCacheKeys cacheKeys) 
-			: base(factory, htmlEncoder)
-		{
-			_umbracoContextFactory = umbracoContextFactory;
-			_cacheKeys = cacheKeys;
-		}
+        public UmbracoCacheTagHelper(CacheTagHelperMemoryCacheFactory factory,
+            HtmlEncoder htmlEncoder,
+            IUmbracoContextFactory umbracoContextFactory,
+            IUmbracoTagHelperCacheKeys cacheKeys)
+            : base(factory, htmlEncoder)
+        {
+            _umbracoContextFactory = umbracoContextFactory;
+            _cacheKeys = cacheKeys;
+        }
 
-		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
-		{
-			using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
-			{
-				var umbracoContext = umbracoContextReference.UmbracoContext;
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+            {
+                var umbracoContext = umbracoContextReference.UmbracoContext;
 
-				// we don't want to enable the cache tag helper if Umbraco is in Preview, or in Debug mode
-				if (umbracoContext.InPreviewMode || umbracoContext.IsDebug)
-				{
-					// Set the endabled flag to false & lest base class
-					// of the cache tag helper do the same stuff as before
-					this.Enabled = false;
-				}
-				else
-				{
-					// Defaults to true - have to explicitly opt out with attribute set to false in Razor
-					if (UpdateCacheKeyOnPublish)
-					{
+                // we don't want to enable the cache tag helper if Umbraco is in Preview, or in Debug mode
+                if (umbracoContext.InPreviewMode || umbracoContext.IsDebug)
+                {
+                    // Set the endabled flag to false & lest base class
+                    // of the cache tag helper do the same stuff as before
+                    this.Enabled = false;
+                }
+                else
+                {
+                    // Defaults to true - have to explicitly opt out with attribute set to false in Razor
+                    if (UpdateCacheKeyOnPublish)
+                    {
                         // So before we go into our base class
                         // Grab the cache key so we can keep track of it & put into some dictionary or collection
                         // and clear all items out in that collection with our notifications on publish
@@ -59,12 +59,12 @@ namespace Our.Umbraco.TagHelpers
                         var cacheKey = new CacheTagKey(this, context);
                         var key = cacheKey.GenerateKey();
                         var hashedKey = cacheKey.GenerateHashedKey();
-						_cacheKeys.CacheKeys.TryAdd(key, cacheKey);
+                        _cacheKeys.CacheKeys.TryAdd(key, cacheKey);
                     }
-				}
+                }
 
                 await base.ProcessAsync(context, output);
             }
-		}
-	}
+        }
+    }
 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -2,9 +2,6 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Our.Umbraco.TagHelpers.CacheKeys;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core;

--- a/README.md
+++ b/README.md
@@ -344,4 +344,4 @@ With this tag helper the child DOM elements inside the `<our-link>` is wrapped w
 
 
 ## Attribution
-The logo for Our.Umbraco.TagHelpers is made by <a href="https://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a>
+The logo for Our.Umbraco.TagHelpers is made by [Freepik](https://www.freepik.com) from [flaticon.com](https://www.flaticon.com)

--- a/README.md
+++ b/README.md
@@ -357,15 +357,49 @@ Essentially this is a convenience for setting
 '''
 
 ### Clearing the Cache 'on publish'
-The DotNet CacheTagHelper really isn't designed to make it easy to clear the cache 'on command' it's designed to vary and then fall out of cache after a period of time, but what if you want your cache instantly refreshed when a publish takes place? This tag helper has the possibility to 'vary' the cache by the last Content/Media/Dictionary Cache Refresh date.
+The DotNet CacheTagHelper really isn't designed to make it easy to clear the cache 'on command' it's designed to vary and then fall out of cache after a period of time, but what if you want your cache instantly refreshed when a publish takes place? This tag helper has the possibility to 'vary' the cache when a piece of content/media or dictionary is published.
 
 '''cshtml
 <our-cache update-cache-key-on-publish="true">[Your Long Running Expensive Code Here]</our-cache>
 '''
 
-With this set to true any publish will trigger a new 'cache key' and therefore a fresh version of the TagOutput will be displayed, with this set, and if no ExpiresAfter is set on the Tag, we default to 24hrs as the lifetime of the Tag's cache.
+With this set to true any publish will remove the item from a list of tracked cached items and therefore a fresh version of the TagOutput will be displayed.
 
-This is set to True by default, how opinionated of us. 
+This is set to True by default, how opinionated of us, so you only need to explictly use the attrivute if you wish to set this to false and not clear the cache item on Umbraco content/media/dictionary publish.
+
+### Examples
+All examples will skip the cache for Umbraco preview mode and debug mode, and evicit cache items anytime Umbraco publishes content, media or dictionary items.
+
+```cshtml
+<our-cache expires-on="new DateTime(2025,1,29,17,02,0)">
+     <p>@DateTime.Now - A set Date in time</p>
+</our-cache>
+
+<our-cache expires-after="TimeSpan.FromSeconds(120)">
+     <p>@DateTime.Now - Every 120 seconds (2minutes)</p>
+</our-cache>
+
+<our-cache vary-by="@Model.UpdateDate.ToString()">
+    <!-- 
+    Note the original cache taghelper would only clear the cache 
+    when the current page model UpdateDate changed.
+
+    Now we will ALSO clear the cache
+    -->
+    <p>@DateTime.Now - When Model.UpdateDate changes</p>
+</our-cache>
+
+<our-cache vary-by="@Model.UpdateDate.ToString()">
+    <!-- Global navigation -->
+    <!-- Need to clear cache when phone number changes on different node -->
+</our-cache>
+
+<our-cache>
+    <!-- Default of 20mins Global navigation -->
+    <!-- A global naviagtion need to clear cache when phone number changes on different node -->
+    <partial name="Navigation" />
+</our-cache>
+```
 
 (NB if you had a thousand tag helpers on your site, all caching large amounts of content, and new publishes to the site occurring every second - this might be detrimental to performance, so do think of the context of your site before setting this value)  
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,15 @@ Essentially this is a convenience for setting
 The Umbraco convention with other Cache Helpers, eg Html.CachedPartial is to clear all memory caches whenever any item is published in the Umbraco Backoffice. By default the our-cache tag helper will do the same, however you can turn this part off on an individual TagHelper basis by setting update-cache-key-on-publish="false".
 
 '''cshtml
-<our-cache update-cache-key-on-publish="false">[Your Long Running Expensive Code Here]</our-cache>
+<our-cache>[Your Long Running Expensive Code Here]</our-cache>
+'''
+is the same as:
+'''cshtml
+<our-cache update-cache-on-publish="true">[Your Long Running Expensive Code Here]</our-cache>
+'''
+But to turn it off:
+'''cshtml
+<our-cache update-cache-on-publish="false">[Your Long Running Expensive Code Here]</our-cache>
 '''
 
 (NB if you had a thousand tag helpers on your site, all caching large amounts of content, and new publishes to the site occurring every second - this might be detrimental to performance, so do think of the context of your site before allowing the cache to be cleared on each publish)  
@@ -378,14 +386,14 @@ All examples will skip the cache for Umbraco preview mode and debug mode, and ev
 </our-cache>
 
 <our-cache>
-    <!-- A global naviagtion needs to be updated across entire site when phone number changes on homepage node -->
+    <!-- A global navigation needs to be updated across entire site when phone number changes on homepage node -->
     <partial name="Navigation" />
 </our-cache>
 
 ```
 This example will turn off the automatic clearing of the tag helper cache if 'any page' is published, but still clear the cache if the individual page is published:
 ```cshtml
-<our-cache update-cache-key-on-publish="false" vary-by="@Model.UpdateDate.ToString()">
+<our-cache update-cache-on-publish="false" vary-by="@Model.UpdateDate.ToString()">
      <p>@DateTime.Now - A set Date in time</p>
 </our-cache>
 ```

--- a/README.md
+++ b/README.md
@@ -357,18 +357,16 @@ Essentially this is a convenience for setting
 '''
 
 ### Clearing the Cache 'on publish'
-The DotNet CacheTagHelper really isn't designed to make it easy to clear the cache 'on command' it's designed to vary and then fall out of cache after a period of time, but what if you want your cache instantly refreshed when a publish takes place? This tag helper has the possibility to 'vary' the cache when a piece of content/media or dictionary is published.
+The Umbraco convention with other Cache Helpers, eg Html.CachedPartial is to clear all memory caches whenever any item is published in the Umbraco Backoffice. By default the our-cache tag helper will do the same, however you can turn this part off on an individual TagHelper basis by setting update-cache-key-on-publish="false".
 
 '''cshtml
-<our-cache update-cache-key-on-publish="true">[Your Long Running Expensive Code Here]</our-cache>
+<our-cache update-cache-key-on-publish="false">[Your Long Running Expensive Code Here]</our-cache>
 '''
 
-With this set to true any publish will remove the item from a list of tracked cached items and therefore a fresh version of the TagOutput will be displayed.
-
-This is set to True by default, how opinionated of us, so you only need to explictly use the attrivute if you wish to set this to false and not clear the cache item on Umbraco content/media/dictionary publish.
+(NB if you had a thousand tag helpers on your site, all caching large amounts of content, and new publishes to the site occurring every second - this might be detrimental to performance, so do think of the context of your site before allowing the cache to be cleared on each publish)  
 
 ### Examples
-All examples will skip the cache for Umbraco preview mode and debug mode, and evicit cache items anytime Umbraco publishes content, media or dictionary items.
+All examples will skip the cache for Umbraco preview mode and debug mode, and evict cache items anytime Umbraco publishes content, media or dictionary items.
 
 ```cshtml
 <our-cache expires-on="new DateTime(2025,1,29,17,02,0)">
@@ -379,30 +377,18 @@ All examples will skip the cache for Umbraco preview mode and debug mode, and ev
      <p>@DateTime.Now - Every 120 seconds (2minutes)</p>
 </our-cache>
 
-<our-cache vary-by="@Model.UpdateDate.ToString()">
-    <!-- 
-    Note the original cache taghelper would only clear the cache 
-    when the current page model UpdateDate changed.
-
-    Now we will ALSO clear the cache
-    -->
-    <p>@DateTime.Now - When Model.UpdateDate changes</p>
-</our-cache>
-
-<our-cache vary-by="@Model.UpdateDate.ToString()">
-    <!-- Global navigation -->
-    <!-- Need to clear cache when phone number changes on different node -->
-</our-cache>
-
 <our-cache>
-    <!-- Default of 20mins Global navigation -->
-    <!-- A global naviagtion need to clear cache when phone number changes on different node -->
+    <!-- A global naviagtion needs to be updated across entire site when phone number changes on homepage node -->
     <partial name="Navigation" />
 </our-cache>
+
 ```
-
-(NB if you had a thousand tag helpers on your site, all caching large amounts of content, and new publishes to the site occurring every second - this might be detrimental to performance, so do think of the context of your site before setting this value)  
-
+This example will turn off the automatic clearing of the tag helper cache if 'any page' is published, but still clear the cache if the individual page is published:
+```cshtml
+<our-cache update-cache-key-on-publish="false" vary-by="@Model.UpdateDate.ToString()">
+     <p>@DateTime.Now - A set Date in time</p>
+</our-cache>
+```
 
 ## Video 📺
 [![How to create ASP.NET TagHelpers for Umbraco](https://user-images.githubusercontent.com/1389894/138666925-15475216-239f-439d-b989-c67995e5df71.png)](https://www.youtube.com/watch?v=3fkDs0NwIE8)


### PR DESCRIPTION
Hi @warrenbuckley this is what I had hacked together following our conversation about adding an Our Umbraco Tag Cache Helper that was at least aware of Preview and Debug modes, and which maybe cleared it's cache whenever something got published, as per Umbraco.CachedPartial - a very blunt mechanism, but kinda what Umbraco people are used to having.

This doesn't really clear the Cache, just varies the cache key, when something is published, which is a bit of a hack / how Dot Net expects you to expire a Tag Cache Helper! I do not know!

But still think it's useful to have a Tag Cache Helper that is aware of Preview and Debug mode

See what you think anyway!

There is hopefully a 'scribe' you can access here, which shows how to test it...

https://scribehow.com/shared/Workflow__2aX25AlzSAWrzDYuXC3l-Q