### PR TITLE
Add null check on BackofficeUser access

### DIFF
--- a/Our.Umbraco.TagHelpers/EditLinkTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/EditLinkTagHelper.cs
@@ -52,7 +52,7 @@ namespace Our.Umbraco.TagHelpers
 
             // Check if the user is logged in to the backoffice
             // and they have access to the content section
-            if (_backofficeUserAccessor.BackofficeUser.IsAllowedToSeeEditLink())
+            if (_backofficeUserAccessor?.BackofficeUser != null && _backofficeUserAccessor.BackofficeUser.IsAllowedToSeeEditLink())
             {
                 // Try & get Umbraco Current Node int ID (Only do this if ContentId has NOT been set)
                 if (_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext) && ContentId == int.MinValue)


### PR DESCRIPTION
This tag helper "sometimes" throws a null reference exception when accessing the BackofficeUser. The addition of the null check helps prevent this issue from occurring.