### PR TITLE
UPDATE: <our-svg> - Caching + Enforcing Viewbox

### DIFF
--- a/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
+++ b/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
@@ -41,7 +41,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         [Test]
         public void NoOutputIfNoMediaOrFileSet()
         {
-            var tagHelper = new InlineSvgTagHelper(null, null, null);
+            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null);
 
             tagHelper.Process(_context, _output);
 
@@ -52,7 +52,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         public void NoOutputIfBothMediaAndFileSet()
         {
             var umbContent = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media);
-            var tagHelper = new InlineSvgTagHelper(null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null)
             {
                 FileSource = "test.svg",
                 MediaItem = umbContent
@@ -66,7 +66,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         [Test]
         public void NoOutputIfFileNotSvg()
         {
-            var tagHelper = new InlineSvgTagHelper(null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null)
             {
                 FileSource = "test.notsvg"
             };
@@ -82,7 +82,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var fileProvider = new Mock<IFileProvider>();
             fileProvider.Setup(p => p.GetFileInfo(It.IsAny<string>())).Returns(Mock.Of<IFileInfo>(f => !f.Exists));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
             {
                 FileSource = "test.svg"
             };
@@ -98,7 +98,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var fileProvider = new Mock<IFileProvider>();
             fileProvider.Setup(p => p.GetFileInfo(It.IsAny<string>())).Returns(Mock.Of<IFileInfo>(f => f.Exists && f.CreateReadStream() == new MemoryStream(Encoding.UTF8.GetBytes("test svg"))));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
             {
                 FileSource = "test.svg"
             };
@@ -116,7 +116,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         {
             var urlProvider = new Mock<IPublishedUrlProvider>();
             urlProvider.Setup(p => p.GetMediaUrl(It.IsAny<IPublishedContent>(), It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>())).Returns((string)null!);
-            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object)
+            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, null, null)
             {
                 MediaItem = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media)
             };
@@ -132,7 +132,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var umbContent = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media);
             var urlProvider = new Mock<IPublishedUrlProvider>();
             urlProvider.Setup(p => p.GetMediaUrl(umbContent, It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>())).Returns("test.notsvg");
-            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object)
+            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, null, null)
             {
                 MediaItem = umbContent
             };
@@ -152,7 +152,9 @@ namespace Our.Umbraco.TagHelpers.Tests
             var tagHelper = new InlineSvgTagHelper(
                 new MediaFileManager(fileSystem, null, null, null, null, Mock.Of<IOptions<ContentSettings>>()),
                 null,
-                urlProvider.Object)
+                urlProvider.Object, 
+                null, 
+                null)
             {
                 MediaItem = umbContent
             };
@@ -172,7 +174,9 @@ namespace Our.Umbraco.TagHelpers.Tests
             var tagHelper = new InlineSvgTagHelper(
                 new MediaFileManager(fileSystem, null, null, null, null, Mock.Of<IOptions<ContentSettings>>()),
                 null,
-                urlProvider.Object)
+                urlProvider.Object, 
+                null, 
+                null)
             {
                 MediaItem = umbContent
             };
@@ -193,7 +197,7 @@ namespace Our.Umbraco.TagHelpers.Tests
                 .Setup(p => p.GetFileInfo(It.IsAny<string>()))
                 .Returns(Mock.Of<IFileInfo>(f => f.Exists && f.CreateReadStream() == new MemoryStream(Encoding.UTF8.GetBytes("<a xlink:href=\"javascript:alert('test');\">Click here</a><script attr=\"test\">test</script>end"))));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
             {
                 FileSource = "test.svg"
             };

--- a/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
+++ b/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
@@ -21,6 +21,7 @@ namespace Our.Umbraco.TagHelpers.Tests
     {
         private TagHelperContext _context = null!;
         private TagHelperOutput _output = null!;
+        private IOptions<OurUmbracoTagHelpersConfiguration> _settings = null!;
 
         [SetUp]
         public void Setup()
@@ -37,11 +38,7 @@ namespace Our.Umbraco.TagHelpers.Tests
                 content.SetContent("Something else");
                 return Task.FromResult<TagHelperContent>(content);
             });
-        }
 
-        [Test]
-        public void NoOutputIfNoMediaOrFileSet()
-        {
             var settings = new OurUmbracoTagHelpersConfiguration()
             {
                 OurSVG =
@@ -51,9 +48,15 @@ namespace Our.Umbraco.TagHelpers.Tests
                     CacheMinutes = 180
                 }
             };
-            IOptions<OurUmbracoTagHelpersConfiguration> tagHelperSettings = Options.Create(settings);
-       
-            var tagHelper = new InlineSvgTagHelper(null, null, null, tagHelperSettings, null);
+            _settings = Options.Create(settings);
+
+        }
+
+        [Test]
+        public void NoOutputIfNoMediaOrFileSet()
+        {
+                    
+            var tagHelper = new InlineSvgTagHelper(null, null, null, _settings, null);
 
             tagHelper.Process(_context, _output);
 
@@ -64,7 +67,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         public void NoOutputIfBothMediaAndFileSet()
         {
             var umbContent = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media);
-            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, null, _settings, null)
             {
                 FileSource = "test.svg",
                 MediaItem = umbContent
@@ -78,7 +81,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         [Test]
         public void NoOutputIfFileNotSvg()
         {
-            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, null, _settings, null)
             {
                 FileSource = "test.notsvg"
             };
@@ -94,7 +97,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var fileProvider = new Mock<IFileProvider>();
             fileProvider.Setup(p => p.GetFileInfo(It.IsAny<string>())).Returns(Mock.Of<IFileInfo>(f => !f.Exists));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, _settings, null)
             {
                 FileSource = "test.svg"
             };
@@ -110,7 +113,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var fileProvider = new Mock<IFileProvider>();
             fileProvider.Setup(p => p.GetFileInfo(It.IsAny<string>())).Returns(Mock.Of<IFileInfo>(f => f.Exists && f.CreateReadStream() == new MemoryStream(Encoding.UTF8.GetBytes("test svg"))));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, _settings, null)
             {
                 FileSource = "test.svg"
             };
@@ -128,7 +131,7 @@ namespace Our.Umbraco.TagHelpers.Tests
         {
             var urlProvider = new Mock<IPublishedUrlProvider>();
             urlProvider.Setup(p => p.GetMediaUrl(It.IsAny<IPublishedContent>(), It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>())).Returns((string)null!);
-            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, _settings, null)
             {
                 MediaItem = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media)
             };
@@ -144,7 +147,7 @@ namespace Our.Umbraco.TagHelpers.Tests
             var umbContent = Mock.Of<IPublishedContent>(c => c.ContentType.ItemType == PublishedItemType.Media);
             var urlProvider = new Mock<IPublishedUrlProvider>();
             urlProvider.Setup(p => p.GetMediaUrl(umbContent, It.IsAny<UrlMode>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Uri>())).Returns("test.notsvg");
-            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, null, urlProvider.Object, _settings, null)
             {
                 MediaItem = umbContent
             };
@@ -164,8 +167,8 @@ namespace Our.Umbraco.TagHelpers.Tests
             var tagHelper = new InlineSvgTagHelper(
                 new MediaFileManager(fileSystem, null, null, null, null, Mock.Of<IOptions<ContentSettings>>()),
                 null,
-                urlProvider.Object, 
-                null, 
+                urlProvider.Object,
+                _settings, 
                 null)
             {
                 MediaItem = umbContent
@@ -186,8 +189,8 @@ namespace Our.Umbraco.TagHelpers.Tests
             var tagHelper = new InlineSvgTagHelper(
                 new MediaFileManager(fileSystem, null, null, null, null, Mock.Of<IOptions<ContentSettings>>()),
                 null,
-                urlProvider.Object, 
-                null, 
+                urlProvider.Object,
+                _settings, 
                 null)
             {
                 MediaItem = umbContent
@@ -209,7 +212,7 @@ namespace Our.Umbraco.TagHelpers.Tests
                 .Setup(p => p.GetFileInfo(It.IsAny<string>()))
                 .Returns(Mock.Of<IFileInfo>(f => f.Exists && f.CreateReadStream() == new MemoryStream(Encoding.UTF8.GetBytes("<a xlink:href=\"javascript:alert('test');\">Click here</a><script attr=\"test\">test</script>end"))));
             var hostEnv = Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == fileProvider.Object);
-            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, null, null)
+            var tagHelper = new InlineSvgTagHelper(null, hostEnv, null, _settings, null)
             {
                 FileSource = "test.svg"
             };

--- a/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
+++ b/Our.Umbraco.TagHelpers.Tests/InlineSvgTagHelperTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using Our.Umbraco.TagHelpers.Configuration;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -41,7 +42,18 @@ namespace Our.Umbraco.TagHelpers.Tests
         [Test]
         public void NoOutputIfNoMediaOrFileSet()
         {
-            var tagHelper = new InlineSvgTagHelper(null, null, null, null, null);
+            var settings = new OurUmbracoTagHelpersConfiguration()
+            {
+                OurSVG =
+                {
+                    Cache = false,
+                    EnsureViewBox = false,
+                    CacheMinutes = 180
+                }
+            };
+            IOptions<OurUmbracoTagHelpersConfiguration> tagHelperSettings = Options.Create(settings);
+       
+            var tagHelper = new InlineSvgTagHelper(null, null, null, tagHelperSettings, null);
 
             tagHelper.Process(_context, _output);
 

--- a/Our.Umbraco.TagHelpers/Composing/InlineSvgTagHelperComposer.cs
+++ b/Our.Umbraco.TagHelpers/Composing/InlineSvgTagHelperComposer.cs
@@ -1,0 +1,20 @@
+﻿using Our.Umbraco.TagHelpers.Notifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Our.Umbraco.TagHelpers.Composing
+{
+    public class InlineSvgTagHelperComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.AddNotificationHandler<MediaSavedNotification, InlineSvgTagHelperNotifications>();
+        }
+    }
+}

--- a/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfiguration.cs
+++ b/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace Our.Umbraco.TagHelpers.Configuration
+{
+    public class OurUmbracoTagHelpersConfiguration
+    {
+        public InlineSvgTagHelperConfiguration OurSVG { get; set; } = new InlineSvgTagHelperConfiguration();
+    }
+
+    public class InlineSvgTagHelperConfiguration
+    {
+        public bool EnsureViewBox { get; set; } = false;
+        public bool Cache { get; set; } = false;
+        public int CacheMinutes { get; set; } = 180;
+    }
+}

--- a/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfigurationComposer.cs
+++ b/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfigurationComposer.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Our.Umbraco.TagHelpers.Services;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace Our.Umbraco.TagHelpers.Configuration
+{
+    public class OurUmbracoTagHelpersConfigurationComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.Services.AddOptions<OurUmbracoTagHelpersConfiguration>()
+                .Bind(builder.Config.GetSection("Our.Umbraco.TagHelpers"));
+        }
+    }
+}

--- a/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
@@ -1,8 +1,13 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using HtmlAgilityPack;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Options;
+using Our.Umbraco.TagHelpers.Configuration;
+using Our.Umbraco.TagHelpers.Utils;
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
@@ -20,12 +25,16 @@ namespace Our.Umbraco.TagHelpers
         private MediaFileManager _mediaFileManager;
         private IWebHostEnvironment _webHostEnvironment;
         private IPublishedUrlProvider _urlProvider;
+        private OurUmbracoTagHelpersConfiguration _globalSettings;
+        private AppCaches _appCaches;
 
-        public InlineSvgTagHelper(MediaFileManager mediaFileManager, IWebHostEnvironment webHostEnvironment, IPublishedUrlProvider urlProvider)
+        public InlineSvgTagHelper(MediaFileManager mediaFileManager, IWebHostEnvironment webHostEnvironment, IPublishedUrlProvider urlProvider, IOptions<OurUmbracoTagHelpersConfiguration> globalSettings, AppCaches appCaches)
         {
             _mediaFileManager = mediaFileManager;
             _webHostEnvironment = webHostEnvironment;
             _urlProvider = urlProvider;
+            _globalSettings = globalSettings.Value;
+            _appCaches = appCaches;
         }
 
         /// <summary>
@@ -42,6 +51,40 @@ namespace Our.Umbraco.TagHelpers
         [HtmlAttributeName("media-item")]
         public IPublishedContent? MediaItem { get; set; }
 
+        /// <summary>
+        /// A classic CSS class property to apply/append a CSS class or classes.
+        /// </summary>
+        [HtmlAttributeName("class")]
+        public string? CssClass { get; set; }
+
+        /// <summary>
+        /// A boolean to ensure a viewbox is present within the SVG tag to ensure the vector is always responsive.
+        /// NOTE: Use the appsettings configuration to apply this globally (e.g. "Our.Umbraco.TagHelpers": { "InlineSvgTagHelper": { "EnsureViewBox": true } } ).
+        /// </summary>
+        [HtmlAttributeName("ensure-viewbox")]
+        public bool EnsureViewBox { get; set; }
+
+        /// <summary>
+        /// A boolean to cache the SVG contents rather than performing the operation on each page load.
+        /// NOTE: Use the appsettings configuration to apply this globally (e.g. "Our.Umbraco.TagHelpers": { "InlineSvgTagHelper": { "Cache": true } } ).
+        /// </summary>
+        [HtmlAttributeName("cache")]
+        public bool Cache { get; set; }
+
+        /// <summary>
+        /// An integer to set the cache minutes. Default: 180 minutes.
+        /// NOTE: Use the appsettings configuration to apply this globally (e.g. "Our.Umbraco.TagHelpers": { "InlineSvgTagHelper": { "CacheMinutes": 180 } } ).
+        /// </summary>
+        [HtmlAttributeName("cache-minutes")]
+        public int CacheMinutes { get; set; }
+
+        /// <summary>
+        /// A boolean to ignore the appsettings. 
+        /// NOTE: Applies to 'ensure-viewbox' & 'cache' only
+        /// </summary>
+        [HtmlAttributeName("ignore-appsettings")]
+        public bool IgnoreAppSettings { get; set; }
+
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             // Can only use media-item OR src
@@ -55,26 +98,66 @@ namespace Our.Umbraco.TagHelpers
                 return;
             }
 
+            string? cleanedFileContents = null;
+
+            if(Cache || (_globalSettings.OurSVG.Cache && !IgnoreAppSettings))
+            {
+                var cacheName = string.Empty;
+                var cacheMins = CacheMinutes > 0 ? CacheMinutes : _globalSettings.OurSVG.CacheMinutes;
+
+                if (MediaItem is not null)
+                {
+                    cacheName = string.Concat("MediaItem-SvgContents (", MediaItem.Key.ToString(), ")");
+                }
+                else if (string.IsNullOrWhiteSpace(FileSource) == false)
+                {
+                    cacheName = string.Concat("File-SvgContents (", FileSource, ")");
+                }
+
+                cleanedFileContents = _appCaches.RuntimeCache.GetCacheItem(cacheName, () =>
+                {
+                    return GetFileContents();
+                }, TimeSpan.FromMinutes(cacheMins));
+            }
+            else
+            {
+                cleanedFileContents = GetFileContents();
+            }
+
+            if (string.IsNullOrEmpty(cleanedFileContents))
+            {
+                output.SuppressOutput();
+                return;
+            }
+
+            // Remove the src attribute or media-item from the <svg>
+            output.Attributes.RemoveAll("src");
+            output.Attributes.RemoveAll("media-item");
+
+            output.TagName = null; // Remove <our-svg>
+            output.Content.SetHtmlContent(cleanedFileContents);
+       }
+
+        private string? GetFileContents()
+        {
             // SVG fileContents to render to DOM
             var fileContents = string.Empty;
 
-            if(MediaItem is not null)
+            if (MediaItem is not null)
             {
                 // Check Umbraco Media Item that is picked/used
                 // has a file that uses a .svg file extension
                 var mediaItemPath = MediaItem.Url(_urlProvider);
                 if (mediaItemPath?.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase) != true)
                 {
-                    output.SuppressOutput();
-                    return;
+                    return null;
                 }
 
                 // Ensure the file actually exists on disk, Azure blob provider or ...
                 // Anywhere else defined by IFileSystem to fetch & store files
                 if (_mediaFileManager.FileSystem.FileExists(mediaItemPath) == false)
                 {
-                    output.SuppressOutput();
-                    return;
+                    return null;
                 }
 
                 // Read its contents (get its stream)
@@ -82,13 +165,12 @@ namespace Our.Umbraco.TagHelpers
                 using var reader = new StreamReader(fileStream);
                 fileContents = reader.ReadToEnd();
             }
-            else if(string.IsNullOrWhiteSpace(FileSource) == false)
+            else if (string.IsNullOrWhiteSpace(FileSource) == false)
             {
                 // Check string src filepath ends with .svg
                 if (FileSource.EndsWith(".svg", StringComparison.InvariantCultureIgnoreCase) == false)
                 {
-                    output.SuppressOutput();
-                    return;
+                    return null;
                 }
 
                 // Get file from wwwRoot using a path such as
@@ -98,10 +180,9 @@ namespace Our.Umbraco.TagHelpers
                 var file = webRoot.GetFileInfo(FileSource);
 
                 // Ensure file exists in wwwroot path
-                if(file.Exists == false)
+                if (file.Exists == false)
                 {
-                    output.SuppressOutput();
-                    return;
+                    return null;
                 }
 
                 using var reader = new StreamReader(file.CreateReadStream());
@@ -120,12 +201,31 @@ namespace Our.Umbraco.TagHelpers
                 @"syntax:error:",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-            // Remove the src attribute or media-item from the <svg>
-            output.Attributes.RemoveAll("src");
-            output.Attributes.RemoveAll("media-item");
+            if ((EnsureViewBox || (_globalSettings.OurSVG.EnsureViewBox && !IgnoreAppSettings)) || !string.IsNullOrEmpty(CssClass))
+            {
+                HtmlDocument doc = new HtmlDocument();
+                doc.LoadHtml(cleanedFileContents);
+                var svgs = doc.DocumentNode.SelectNodes("//svg");
+                foreach (var svgNode in svgs)
+                {
+                    if (!string.IsNullOrEmpty(CssClass))
+                    {
+                        svgNode.AddClass(CssClass);
+                    }
+                    if ((EnsureViewBox || (_globalSettings.OurSVG.EnsureViewBox && !IgnoreAppSettings)) && svgNode.Attributes.Contains("width") && svgNode.Attributes.Contains("height") && !svgNode.Attributes.Contains("viewbox"))
+                    {
+                        var width = StringUtils.GetDecimal(svgNode.GetAttributeValue("width", "0"));
+                        var height = StringUtils.GetDecimal(svgNode.GetAttributeValue("height", "0"));
+                        svgNode.SetAttributeValue("viewbox", $"0 0 {width} {height}");
 
-            output.TagName = null; // Remove <our-svg>
-            output.Content.SetHtmlContent(cleanedFileContents);
-       }
+                        svgNode.Attributes.Remove("width");
+                        svgNode.Attributes.Remove("height");
+                    }
+                }
+                cleanedFileContents = doc.DocumentNode.OuterHtml;
+            }
+
+            return cleanedFileContents;
+        }
     }
 }

--- a/Our.Umbraco.TagHelpers/Notifications/InlineSvgTagHelperNotifications.cs
+++ b/Our.Umbraco.TagHelpers/Notifications/InlineSvgTagHelperNotifications.cs
@@ -32,7 +32,7 @@ namespace Our.Umbraco.TagHelpers.Notifications
                     if (_appCaches.RuntimeCache.SearchByKey(cacheKey).Any())
                     {
                         _appCaches.RuntimeCache.ClearByKey(cacheKey);
-                        _logger.LogDebug($"Removed {mediaItem.Name} from RuntimeCache");
+                        _logger.LogDebug("Removed {MediaItemName} from RuntimeCache", mediaItem.Name);
                     }
                 }
             }

--- a/Our.Umbraco.TagHelpers/Notifications/InlineSvgTagHelperNotifications.cs
+++ b/Our.Umbraco.TagHelpers/Notifications/InlineSvgTagHelperNotifications.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace Our.Umbraco.TagHelpers.Notifications
+{
+    public class InlineSvgTagHelperNotifications : INotificationHandler<MediaSavedNotification>
+    {
+        private readonly ILogger<InlineSvgTagHelperNotifications> _logger;
+        private readonly AppCaches _appCaches;
+
+        public InlineSvgTagHelperNotifications(ILogger<InlineSvgTagHelperNotifications> logger, AppCaches appCaches)
+        {
+            _logger = logger;
+            _appCaches = appCaches;
+        }
+
+        public void Handle(MediaSavedNotification notification)
+        {
+            foreach (var mediaItem in notification.SavedEntities)
+            {
+                if (mediaItem.ContentType.Alias.Equals("umbracoMediaVectorGraphics", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var cacheKey = string.Concat("MediaItem-SvgContents (", mediaItem.Key.ToString(), ")");
+                    if (_appCaches.RuntimeCache.SearchByKey(cacheKey).Any())
+                    {
+                        _appCaches.RuntimeCache.ClearByKey(cacheKey);
+                        _logger.LogDebug($"Removed {mediaItem.Name} from RuntimeCache");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Our.Umbraco.TagHelpers/Utils/StringUtils.cs
+++ b/Our.Umbraco.TagHelpers/Utils/StringUtils.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.TagHelpers.Utils
+{
+    internal static class StringUtils
+    {
+        internal static double GetDouble(object value, double defaultValue = 0)
+        {
+            double num;
+            if (!IsDouble(value))
+            {
+                return defaultValue;
+            }
+            try
+            {
+                num = Convert.ToDouble(value);
+            }
+            catch
+            {
+                num = defaultValue;
+            }
+            return num;
+        }
+
+        internal static decimal GetDecimal(object input, decimal defaultValue = 0)
+        {
+            decimal value = decimal.MinValue;
+            decimal.TryParse(input != null ? input.ToString().Replace("£", "") : "", out value);
+
+            if (value > decimal.MinValue)
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+
+        internal static int GetInteger(object input, int defaultValue = 0)
+        {
+            var value = 0;
+            int.TryParse(input != null ? input.ToString() : "", out value);
+
+            if (value > 0)
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+
+        internal static bool IsDouble(object value)
+        {
+            double num;
+            if (IsNull(value))
+            {
+                return false;
+            }
+            if (value is double)
+            {
+                return true;
+            }
+            string str = Convert.ToString(value);
+            if (double.TryParse(str, out num))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        internal static bool IsNull(object value)
+        {
+            if (value == null)
+            {
+                return true;
+            }
+            return value == DBNull.Value;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -182,10 +182,43 @@ If you do not specify a template and use `<our-lang-switcher />` it will use the
 This tag helper element `<our-svg>` will read the file contents of an SVG file and output it as an inline SVG in the DOM.
 It can be used in one of two ways, either by specifying the `src` attribute to a physcial static file served from wwwRoot or by specifying the `media-item` attribute to use a picked IPublishedContent Media Item.
 
+### Basic usage:
 ```cshtml
 <our-svg src="/assets/icon.svg" />
 <our-svg media-item="@Model.Logo" />
 ```
+
+### Advanced usage: *(as of version 1.x.x)
+
+Additional properties have been added to cache the output and also to ensure the SVG contains a viewbox property instead of the width & height properties to aid in making the vector image responsive within a parent HTML element. 
+```cshtml
+<our-svg src="/assets/icon.svg" class="my-css-class" ensure-viewbox="true" cache="true" cache-minutes="180" ignore-appsettings="true" />
+<our-svg media-item="@Model.Logo" class="my-css-class" ensure-viewbox="true" cache="true" cache-minutes="180" ignore-appsettings="true" />
+```
+
+- `class` - Allows for a CSS class upon the SVG element. This is a `string` value.
+- `ensure-viewbox` - Enables the feature to "fix" the output SVG which always ensures the SVG utilises a viewbox rather than width & height. This is a `boolean` value.
+- `cache` - Enables the feature to cache the output at runtime level. This is a `boolean` value.
+- `cache-minutes` - Defines the amount of time (in minutes) to cache the output. To be used in conjunction with the `cache` property. This is an `integer` value.
+- `ignore-appsettings` - When enabled, the all settings appropiate to this tag helper which are defined within `appsettings.json` are completely ignored. For example, if global caching is enabled we can simply disable caching of individual elements (unless the `cache` property is `true`). This is a `boolean` value.
+
+### Global settings via appsettings.json
+
+Applying any of the below configurations within your `appsettings.json` file will apply global settings to all elements using this tag helper. See the `ignore-appsettings` to override these global settings at element level. The values shown below are the hard-coded default values.
+
+    {
+      "Our.Umbraco.TagHelpers": {
+        "OurSVG": {
+          "EnsureViewBox": false,
+          "Cache": false,
+          "CacheMinutes": 180
+        }
+      }
+    }
+
+> **Note:** SVG caches are cleared on application restart, or by resaving the media in the media library.
+
+    
 
 ## `<our-fallback>`
 This tag helper element `<our-fallback>` uses the same fallback mode logic that is only available on the `Value()` method of the `IPublishedContent` interface that uses a string for the property name to lookup. In addition if the fallback value from a language or ancestors is not available we are still able to fallback to the content inside the tag.


### PR DESCRIPTION
### `<our-svg>`
- Updated Readme with changes
- Added new configurations to appsettings.json to set global output caching of SVG contents & 'fixing' SVG's to ensure they have a viewbox property rather than width & height properties.
- Added new tag helper properties to override global configurations & apply CSS classes to the SVG element
- Added new MediaSavedNotification to clear SVG cache on save of the media item.