### PR TITLE
Updated BackofficeUserAccessor to use ChunkingCookieManager

### DIFF
--- a/Our.Umbraco.TagHelpers/Services/BackofficeUserAccessor.cs
+++ b/Our.Umbraco.TagHelpers/Services/BackofficeUserAccessor.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
@@ -26,6 +25,11 @@ namespace Our.Umbraco.TagHelpers.Services
             _httpContextAccessor = httpContextAccessor;
         }
 
+
+        /// <summary>
+        /// Updated to use ChunkingCookieManager as per Sean Maloney's answer on our.umbraco.com
+        /// https://our.umbraco.com/forum/umbraco-9/106857-how-do-i-determine-if-a-backoffice-user-is-logged-in-from-a-razor-view#comment-341847
+        /// </summary>
         public ClaimsIdentity BackofficeUser
         {
             get
@@ -35,16 +39,17 @@ namespace Our.Umbraco.TagHelpers.Services
                 if (httpContext == null)
                     return new ClaimsIdentity();
 
-                CookieAuthenticationOptions cookieOptions = _cookieOptionsSnapshot.Get(global::Umbraco.Cms.Core.Constants.Security.BackOfficeAuthenticationType);
-                string? backOfficeCookie = httpContext.Request.Cookies[cookieOptions.Cookie.Name!];
+                var cookieOptions = _cookieOptionsSnapshot.Get(global::Umbraco.Cms.Core.Constants.Security.BackOfficeAuthenticationType);
+                var cookieManager = new ChunkingCookieManager();
+                var backOfficeCookie = cookieManager.GetRequestCookie(httpContext, cookieOptions.Cookie.Name!);
 
                 if (string.IsNullOrEmpty(backOfficeCookie))
                     return new ClaimsIdentity();
 
-                AuthenticationTicket? unprotected = cookieOptions.TicketDataFormat.Unprotect(backOfficeCookie!);
-                ClaimsIdentity backOfficeIdentity = unprotected!.Principal.GetUmbracoIdentity();
+                var unprotected = cookieOptions.TicketDataFormat.Unprotect(backOfficeCookie!);
+                var backOfficeIdentity = unprotected!.Principal.GetUmbracoIdentity();
 
-                return backOfficeIdentity;
+                return backOfficeIdentity ?? new ClaimsIdentity();
             }
         }
     }


### PR DESCRIPTION
Sometimes the backend user cookie will get split into chunks if it's too long, for example:

![image](https://user-images.githubusercontent.com/19938510/208527162-0c07a51e-2c37-4411-b1dd-8b0f29348231.png)

When this happens, the current code will throw a null exception. This pull request implementes a fix provided by Sean Maloney on [our.umbraco.com](https://our.umbraco.com/forum/umbraco-9/106857-how-do-i-determine-if-a-backoffice-user-is-logged-in-from-a-razor-view#comment-341847).

Have tested on both the ExampleSite and on my own project and can confirm it works.