### PR TITLE
Fixed null error

### DIFF
--- a/Our.Umbraco.TagHelpers/Services/BackofficeUserAccessor.cs
+++ b/Our.Umbraco.TagHelpers/Services/BackofficeUserAccessor.cs
@@ -42,9 +42,9 @@ namespace Our.Umbraco.TagHelpers.Services
                     return new ClaimsIdentity();
 
                 AuthenticationTicket? unprotected = cookieOptions.TicketDataFormat.Unprotect(backOfficeCookie!);
-                ClaimsIdentity backOfficeIdentity = unprotected!.Principal.GetUmbracoIdentity();
+                ClaimsIdentity? backOfficeIdentity = unprotected?.Principal.GetUmbracoIdentity();
 
-                return backOfficeIdentity;
+                return backOfficeIdentity ?? new ClaimsIdentity();
             }
         }
     }


### PR DESCRIPTION
When you are on localhost with another site that you are logged into, line `39` picks up the cookie, but it is not valid for this site. 

This makes the `unprotected` variable null and throws an error.

This code fix checks if `unprotected` is null first and handles it accordingly.