### PR TITLE
Make UmbracoTagHelperCacheKeys Threadsafe

### DIFF
--- a/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/IUmbracoTagHelperCacheKeys.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Our.Umbraco.TagHelpers.Services
 {
 	public interface IUmbracoTagHelperCacheKeys
 	{
-		Dictionary<string, CacheTagKey> CacheKeys { get; }
+        ConcurrentDictionary<string, CacheTagKey> CacheKeys { get; }
 	}
 }

--- a/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
+++ b/Our.Umbraco.TagHelpers/Services/UmbracoTagHelperCacheKeys.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Our.Umbraco.TagHelpers.Services
 {
@@ -9,6 +9,6 @@ namespace Our.Umbraco.TagHelpers.Services
 	/// </summary>
 	public class UmbracoTagHelperCacheKeys : IUmbracoTagHelperCacheKeys
 	{
-		public Dictionary<string,CacheTagKey> CacheKeys { get; } = new Dictionary<string,CacheTagKey>();
+		public ConcurrentDictionary<string,CacheTagKey> CacheKeys { get; } = new ConcurrentDictionary<string,CacheTagKey>();
 	}
 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Our.Umbraco.TagHelpers.Services;
-using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core;
@@ -63,7 +62,7 @@ namespace Our.Umbraco.TagHelpers
                         // and clear all items out in that collection with our notifications on publish
                         var cacheKey = new CacheTagKey(this, context);
                         var key = cacheKey.GenerateKey();
-                        _ = cacheKey.GenerateHashedKey();
+                        var hashedKey = cacheKey.GenerateHashedKey();
                         _cacheKeys.CacheKeys.TryAdd(key, cacheKey);
                     }
                 }

--- a/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/UmbracoCacheTagHelper.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Our.Umbraco.TagHelpers.Services;
+using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core;
@@ -62,7 +63,7 @@ namespace Our.Umbraco.TagHelpers
                         // and clear all items out in that collection with our notifications on publish
                         var cacheKey = new CacheTagKey(this, context);
                         var key = cacheKey.GenerateKey();
-                        var hashedKey = cacheKey.GenerateHashedKey();
+                        _ = cacheKey.GenerateHashedKey();
                         _cacheKeys.CacheKeys.TryAdd(key, cacheKey);
                     }
                 }


### PR DESCRIPTION
UmbracoTagHelperCacheKeys is vulnerable to concurrency issues because the Dictionary used is not thread safe, This PR just changes the type of that property from Dictionary to ConcurrentDictionary.