### PR TITLE
Fix for img tag helper not outputting alt attribute when specified

### DIFF
--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -180,15 +180,13 @@ namespace Our.Umbraco.TagHelpers
                     height = (originalHeight / originalWidth) * width;
                 }
 
-                #region Autogenerate alt text
+                #region Autogenerate alt text if unspecfied
                 if (string.IsNullOrWhiteSpace(ImgAlt))
                 {
                     output.Attributes.Add("alt", GetImageAltText(MediaItem));
                 }
-				#endregion
-				#region Use the alt text the user specified
-				else
-				{
+                else
+                {
                     output.Attributes.Add("alt", ImgAlt);
                 }
                 #endregion
@@ -201,18 +199,16 @@ namespace Our.Umbraco.TagHelpers
 
                 imgSrc = AddQueryToUrl(FileSource, "width", width.ToString());
 
-                #region Autogenerate alt text
+                #region Autogenerate alt text if unspecfied
                 if (string.IsNullOrWhiteSpace(ImgAlt))
                 {
                     output.Attributes.Add("alt", GetImageAltText(FileSource));
                 }
-				#endregion
-				#region Use the alt text the user specified
-				else
-				{
-					output.Attributes.Add("alt", ImgAlt);
-				}
-				#endregion
+                else
+                {
+                    output.Attributes.Add("alt", ImgAlt);
+                }
+                #endregion
 
 				#region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
 				if (ImgWidth == 0 || ImgHeight == 0)

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -185,7 +185,12 @@ namespace Our.Umbraco.TagHelpers
                 {
                     output.Attributes.Add("alt", GetImageAltText(MediaItem));
                 }
-                #endregion
+				#endregion
+				#region Use the alt text the user specified
+				else
+				{
+                    output.Attributes.Add("alt", ImgAlt);
+                }
                 #endregion
             }
             else if (!string.IsNullOrEmpty(FileSource))
@@ -201,10 +206,16 @@ namespace Our.Umbraco.TagHelpers
                 {
                     output.Attributes.Add("alt", GetImageAltText(FileSource));
                 }
-                #endregion
+				#endregion
+				#region Use the alt text the user specified
+				else
+				{
+					output.Attributes.Add("alt", ImgAlt);
+				}
+				#endregion
 
-                #region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
-                if (ImgWidth == 0 || ImgHeight == 0)
+				#region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
+				if (ImgWidth == 0 || ImgHeight == 0)
                 {
                     output.Attributes.Add("src", FileSource);
 

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -209,8 +209,8 @@ namespace Our.Umbraco.TagHelpers
                     output.Attributes.Add("alt", ImgAlt);
                 }
                 #endregion
-
-				#region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
+                
+                #region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
 				if (ImgWidth == 0 || ImgHeight == 0)
                 {
                     output.Attributes.Add("src", FileSource);

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -209,9 +209,9 @@ namespace Our.Umbraco.TagHelpers
                     output.Attributes.Add("alt", ImgAlt);
                 }
                 #endregion
-                
+
                 #region If width & height are not defined then return a basic <img> with just a src, alt & class (if provided)
-				if (ImgWidth == 0 || ImgHeight == 0)
+                if (ImgWidth == 0 || ImgHeight == 0)
                 {
                     output.Attributes.Add("src", FileSource);
 


### PR DESCRIPTION
When you use the img tag helper as follows no alt attribute is output:

`<our-img src="/images/logo.png" alt="Img alt" />`

At the moment an alt attribute is only output if a value isn't specified, which triggers the auto generation of the alt attribute value.  This PR handles the case when an alt attribute is specified and adds that value to the output.