### PR TITLE
Caching SVG doesn't cache CSS class name and Viewbox settings

### DIFF
--- a/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
@@ -201,6 +201,17 @@ namespace Our.Umbraco.TagHelpers
                 @"syntax:error:",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
+            cleanedFileContents = ParseAndSetAttrs(cleanedFileContents);
+
+            return cleanedFileContents;
+        }
+
+        /// <summary>
+        /// Set CSS Class, Viewbox, and/or width/height
+        /// </summary>
+        /// <param name="cleanedFileContents">SVG file contents</param>
+        /// <returns>SVG file contents with attributes</returns>
+        private string ParseAndSetAttrs (string cleanedFileContents) {
             if ((EnsureViewBox || (_globalSettings.OurSVG.EnsureViewBox && !IgnoreAppSettings)) || !string.IsNullOrEmpty(CssClass))
             {
                 HtmlDocument doc = new HtmlDocument();

--- a/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/InlineSvgTagHelper.cs
@@ -130,6 +130,9 @@ namespace Our.Umbraco.TagHelpers
                 return;
             }
 
+            // Set CSS Class, Viewbox, and/or width/height
+            cleanedFileContents = ParseAndSetAttrs(cleanedFileContents);
+
             // Remove the src attribute or media-item from the <svg>
             output.Attributes.RemoveAll("src");
             output.Attributes.RemoveAll("media-item");
@@ -200,8 +203,6 @@ namespace Our.Umbraco.TagHelpers
                 @"javascript:",
                 @"syntax:error:",
                 RegexOptions.IgnoreCase | RegexOptions.Singleline);
-
-            cleanedFileContents = ParseAndSetAttrs(cleanedFileContents);
 
             return cleanedFileContents;
         }


### PR DESCRIPTION
There is an issue where caching an SVG with a class name (or Viewbox setting) causes the class name to be contained in the cache. If outputting the same SVG later includes the class name from the first usage.

This PR splits the caching so that the file read is independently cached from the Css class name and Viewbox settings.