### PR TITLE
Add in JSON Schema for completions for appsettings

### DIFF
--- a/Our.Umbraco.TagHelpers/buildTransitive/Our.Umbraco.TagHelpers.props‎
+++ b/Our.Umbraco.TagHelpers/buildTransitive/Our.Umbraco.TagHelpers.props‎
@@ -1,0 +1,5 @@
+<Project>
+	<ItemGroup>
+		<UmbracoJsonSchemaFiles Include="$(MSBuildThisFileDirectory)..\appsettings-schema.our.umbraco.taghelpers.json" Weight="-80" />
+	</ItemGroup>
+</Project>

--- a/appsettings-schema.our.umbraco.taghelpers.json
+++ b/appsettings-schema.our.umbraco.taghelpers.json
@@ -103,13 +103,13 @@
                     "description": "Settings for the taghelper our-self-host",
                     "properties": {
                         "RootFolder": {
-                            "type":"string",
-                            "description": "",
+                            "type": "string",
+                            "description": "The folder locaton to store the self hosted assets in",
                             "default": "/assets"
                         }
                     }
                 }
-
             }
         }
     }
+}

--- a/appsettings-schema.our.umbraco.taghelpers.json
+++ b/appsettings-schema.our.umbraco.taghelpers.json
@@ -1,0 +1,115 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "JSON Schema for Umbraco package Our.Umbraco.TagHelpers",
+    "type": "object",
+    "properties": {
+        "Our.Umbraco.TagHelpers": {
+            "description": "Settings for Our.Umbraco.TagHelpers package",
+            "properties": {
+                "OurSVG": {
+                    "description": "Settings for the taghelper our-svg",
+                    "properties": {
+                        "EnsureViewBox": {
+                            "type": "boolean",
+                            "description": "Enables the feature to 'fix' the output SVG which always ensures the SVG utilises a viewbox rather than width & height",
+                            "default": false
+                        },
+                        "Cache": {
+                            "type": "boolean",
+                            "description": "Enables the feature to cache the output at runtime level",
+                            "default": false
+                        },
+                        "CacheMinutes": {
+                            "type": "integer",
+                            "description": "Defines the amount of time (in minutes) to cache the output. To be used in conjunction with the cache property",
+                            "default": 180
+                        }
+                    }
+                },
+                "OurIMG": {
+                    "description": "Settings for the taghelper our-img",
+                    "properties": {
+                        "MobileFirst": {
+                            "type": "boolean",
+                            "description": "Alternates between min-width & max-width media queries. When enabled, min-width is used.",
+                            "default": true
+                        },
+                        "UseNativeLazyLoading": {
+                            "type": "boolean",
+                            "description": "If enabled, loading='true' is used. If disabled, the 'src' property is replaced with 'data-src' which most lazy loading JavaScript libraries will interpret and lazy load the image.",
+                            "default": true
+                        },
+                        "LazyLoadCssClass": {
+                            "type": "string",
+                            "description": "If 'UseNativeLazyLoading' is disabled, the class property is given an additional class for JavaScript libraries to target. Note: 'lazyload' is used by the lazysizes library.",
+                            "default": "lazyload"
+                        },
+                        "LazyLoadPlaceholder": {
+                            "type": "string",
+                            "enum": [
+                                "SVG",
+                                "LowQualityImage"
+                            ],
+                            "description": "TODO: Think can only be SVG or LowQualityImage"
+                        },
+                        "LazyLoadPlaceholderLowQualityImageQuality": {
+                            "type": "integer",
+                            "description": "If 'UseNativeLazyLoading' is disabled and 'LazyLoadPlaceholder' is 'LowQualityImage', what image quality should be rendered. Numeric values 1-100 accepted.",
+                            "default": 5
+                        },
+                        "ApplyAspectRatio": {
+                            "type": "boolean",
+                            "description": "If enabled, the aspect-ratio CSS style is applied to the style property, and the width & height properties are removed.",
+                            "default": false
+                        },
+                        "AlternativeTextMediaTypePropertyAlias": {
+                            "type": "string",
+                            "description": "The media property alias to pull through the alt text value. If not found, the media title or filename will be used instead.",
+                            "default": "alternativeText"
+                        },
+                        "MediaQueries": {
+                            "description": "Window breakpoint widths in pixels",
+                            "properties": {
+                                "Small": {
+                                    "type": "integer",
+                                    "description": "Width in pixels for small breakpoint",
+                                    "default": 576
+                                },
+                                "Medium": {
+                                    "type": "integer",
+                                    "description": "Width in pixels for medium breakpoint",
+                                    "default": 768
+                                },
+                                "Large": {
+                                    "type": "integer",
+                                    "description": "Width in pixels for large breakpoint",
+                                    "default": 992
+                                },
+                                "ExtraLarge": {
+                                    "type": "integer",
+                                    "description": "Width in pixels for extra large breakpoint",
+                                    "default": 1200
+                                },
+                                "ExtraExtraLarge": {
+                                    "type": "integer",
+                                    "description": "Width in pixels for extra extra large breakpoint",
+                                    "default": 1400
+                                }
+                            }
+                        }
+                    }
+                },
+                "OurSelfHost": {
+                    "description": "Settings for the taghelper our-self-host",
+                    "properties": {
+                        "RootFolder": {
+                            "type":"string",
+                            "description": "",
+                            "default": "/assets"
+                        }
+                    }
+                }
+
+            }
+        }
+    }


### PR DESCRIPTION
Fixes #80 

Adding JSON Schema only to 16.0.0 build as the v1.x builds started from Umbraco 9.0 where it can still be installed into and where [Umbraco Package JSON Schema was not added until v11](https://github.com/umbraco/Umbraco-CMS/pull/13427)